### PR TITLE
Package license in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include inc/*.h
+include LICENSE.txt


### PR DESCRIPTION
While working on https://github.com/conda-forge/staged-recipes/pull/9881, I noticed that the `LICENSE.txt` file is not included in the source distribution on PyPI. This PR is going to fix the missing file.

Old dirs/files structure before the fix (from the archive produced by `python setup.py sdist`)
```bash
$ tree pystackreg-0.2.2
pystackreg-0.2.2
├── MANIFEST.in
├── PKG-INFO
├── README.rst
├── inc
│   ├── TurboReg.h
│   ├── TurboRegImage.h
│   ├── TurboRegMask.h
│   ├── TurboRegPointHandler.h
│   ├── TurboRegTransform.h
│   └── matrix.h
├── pystackreg
│   ├── __init__.py
│   ├── pystackreg.py
│   └── version.py
├── pystackreg.egg-info
│   ├── PKG-INFO
│   ├── SOURCES.txt
│   ├── dependency_links.txt
│   ├── requires.txt
│   └── top_level.txt
├── setup.cfg
├── setup.py
└── src
    ├── TurboReg.cpp
    ├── TurboRegImage.cpp
    ├── TurboRegMask.cpp
    ├── TurboRegPointHandler.cpp
    ├── TurboRegTransform.cpp
    └── pymain.cpp

4 directories, 25 files
```

New structure after the fix:
```bash
$ tree pystackreg-0.2.2
pystackreg-0.2.2
├── LICENSE.txt
├── MANIFEST.in
├── PKG-INFO
├── README.rst
├── inc
│   ├── TurboReg.h
│   ├── TurboRegImage.h
│   ├── TurboRegMask.h
│   ├── TurboRegPointHandler.h
│   ├── TurboRegTransform.h
│   └── matrix.h
├── pystackreg
│   ├── __init__.py
│   ├── pystackreg.py
│   └── version.py
├── pystackreg.egg-info
│   ├── PKG-INFO
│   ├── SOURCES.txt
│   ├── dependency_links.txt
│   ├── requires.txt
│   └── top_level.txt
├── setup.cfg
├── setup.py
└── src
    ├── TurboReg.cpp
    ├── TurboRegImage.cpp
    ├── TurboRegMask.cpp
    ├── TurboRegPointHandler.cpp
    ├── TurboRegTransform.cpp
    └── pymain.cpp

4 directories, 26 files
```