### PR TITLE
parallelize register/transform stack

### DIFF
--- a/pystackreg/pystackreg.py
+++ b/pystackreg/pystackreg.py
@@ -373,7 +373,7 @@ class StackReg:
         :type processes: int, optional
         :param processes:
             Set the number of processes that will be used when transforming the
-            stack, only used in the case were reference == 'mean'
+            stack, only used in the case were reference is 'mean' or 'first'
 
         :rtype:  ndarray(img.shape[axis], 3, 3)
         :return: The transformation matrix for each image in the stack
@@ -427,7 +427,7 @@ class StackReg:
 
         iterable = range(idx_start, img.shape[axis])
 
-        if reference == 'mean' and processes>1:
+        if reference in ['mean','first'] and processes>1:
             with Pool(processes=processes) as pool:
                 pool_iter = pool.imap_unordered(self.reg_help, [[ref, simple_slice(img, i , axis),i] for i in iterable])
                 if verbose:
@@ -553,7 +553,7 @@ class StackReg:
         :type processes: int, optional
         :param processes:
             Set the number of processes that will be used when transforming the
-            stack, only used in the case were reference == 'mean'
+            stack, only used in the case were reference is 'mean' or 'first'
 
         :rtype:  ndarray(Ni..., Nj..., Nk...)
         :return: The transformed stack


### PR DESCRIPTION
Use pool to parallelize stack registration, added a variable `processes` that sets the number of processes to use. If it is 1 the original code is executed if it is larger than one the parallelized code will run.
note that progress_callback does not work with the parallelized version