### PR TITLE
Axis argument not used for method "mean" in register_stack()

### DIFF
--- a/pystackreg/pystackreg.py
+++ b/pystackreg/pystackreg.py
@@ -350,7 +350,7 @@ class StackReg:
         if reference == "first":
             ref = np.mean(img.take(range(n_frames), axis=axis), axis=axis)
         elif reference == "mean":
-            ref = img.mean(axis=0)
+            ref = img.mean(axis=axis)
             idx_start = 0
         elif reference == "previous":
             pass


### PR DESCRIPTION
Hey,

thanks for the nice project. Helped me to implement a decent motion correction for some 2D MRI data in a couple of minutes 👍 

In the current version the axis argument for method "mean" in register_stack() was hard coded to 0 instead of using the "axis" variable. This lead to errors when using an axis other than 0. A simple change from "0" to "axis" solves the problem. 